### PR TITLE
Add --no-color option to git grep

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -16,7 +16,7 @@ module.exports =
 
     run: (@search, @rootPath, callback)->
       if @useGitGrep and @isGitRepo()
-        @commandString = 'git grep -n -e'
+        @commandString = 'git grep --no-color -n -e'
         @columnArg = false
       [command, args...] = @commandString.split(/\s/)
       args.push @search


### PR DESCRIPTION
`git grep` may be enabled a color highlight. This PR is disabled a color highlight.

![screen shot 2015-05-25 at 22 58 25](https://cloud.githubusercontent.com/assets/250407/7798215/dda9699e-0331-11e5-831d-04dd6fc025e2.png)
