### PR TITLE
Fix getProjectPath() for symbolic links

### DIFF
--- a/lib/atom-fuzzy-grep-view.coffee
+++ b/lib/atom-fuzzy-grep-view.coffee
@@ -70,11 +70,9 @@ class GrepView extends SelectListView
 
   getProjectPath: ->
     editor = atom.workspace.getActiveTextEditor()
-    if editor && editor.buffer.file
-    # TODO not sure if this a proper way
-      atom.project.getPaths().filter((item)->
-        editor.buffer.file.path.startsWith item
-      )[0]
+    return unless editor
+    if editor.getPath()
+      atom.project.relativizePath(editor.getPath())[0]
     else
       atom.project.getPaths()[0]
 


### PR DESCRIPTION
The original `getProjectPath()` returned `undefined`, if the project root was a symbolic link.

This fixes https://github.com/geksilla/atom-fuzzy-grep/issues/5.
