### PR TITLE
Make 'git grep' command selectable, and default to ignoring case

### DIFF
--- a/lib/atom-fuzzy-grep.coffee
+++ b/lib/atom-fuzzy-grep.coffee
@@ -2,20 +2,27 @@ GrepView = null
 
 module.exports =
   config:
-    detectGitProjectAndUseGitGrep:
-      type: 'boolean'
-      default: true
-      order: 0
     minSymbolsToStartSearch:
       type: 'number'
       default: 3
+      order: 0
+    maxCandidates:
+      type: 'number'
+      default: 100
       order: 1
     grepCommandString:
       type: 'string'
       default: 'ag -i --nocolor --nogroup --column'
-    maxCandidates:
-      type: 'number'
-      default: 100
+      order: 2
+    detectGitProjectAndUseGitGrep:
+      type: 'boolean'
+      default: true
+      order: 3
+    gitGrepCommandString:
+      type: 'string'
+      default: 'git grep -i --no-color -n -e'
+      order: 4
+    
 
   activate: ->
     @editorSubscription = atom.commands.add 'atom-workspace',

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -16,7 +16,7 @@ module.exports =
 
     run: (@search, @rootPath, callback)->
       if @useGitGrep and @isGitRepo()
-        @commandString = 'git grep --no-color -n -e'
+        @commandString = atom.config.get 'atom-fuzzy-grep.gitGrepCommandString'
         @columnArg = false
       [command, args...] = @commandString.split(/\s/)
       args.push @search


### PR DESCRIPTION
When using this package, I realized that the `ag` command being used by default included `-i` to ignore case, but the `git grep` command did not. Then I realized that the `git grep` command was not in the settings. So I thought I would fix that.

These two commits do 3 things:
1. Make the `git grep` command an option, the same as the normal command
2. Reorder the options, to put the `git grep` command under its checkbox
3. Make the `git grep` command also default to having `-i` and ignoring case

Let me know what you think!
