### PR TITLE
Find & Replace before setSelection

### DIFF
--- a/lib/atom-fuzzy-grep-view.coffee
+++ b/lib/atom-fuzzy-grep-view.coffee
@@ -27,6 +27,8 @@ class GrepView extends SelectListView
       @maxItems = atom.config.get 'atom-fuzzy-grep.maxCandidates'
     atom.config.observe 'atom-fuzzy-grep.preserveLastSearch', =>
       @preserveLastSearch = atom.config.get('atom-fuzzy-grep.preserveLastSearch') is true
+    atom.config.observe 'atom-fuzzy-grep.grepCommandFindAndReplace', =>
+      @grepCommandFindAndReplace = atom.config.get 'atom-fuzzy-grep.grepCommandFindAndReplace'
 
   getFilterKey: ->
 
@@ -89,7 +91,15 @@ class GrepView extends SelectListView
   setSelection: ->
     editor = atom.workspace.getActiveTextEditor()
     if editor?.getSelectedText()
-      @filterEditorView.setText(editor.getSelectedText())
+      text = editor.getSelectedText()
+      if @grepCommandFindAndReplace
+        len = @grepCommandFindAndReplace.length
+        for e, i in @grepCommandFindAndReplace by 2
+          if len > i+1
+            findstr = @grepCommandFindAndReplace[i]
+            replacestr = @grepCommandFindAndReplace[i+1]
+            text = text.replace(findstr, replacestr)
+      @filterEditorView.setText(text)
 
   destroy: ->
     @detach()

--- a/lib/atom-fuzzy-grep.coffee
+++ b/lib/atom-fuzzy-grep.coffee
@@ -26,6 +26,12 @@ module.exports =
       type: 'boolean'
       default: false
       order: 5
+    grepCommandFindAndReplace:
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
+        default: ''
 
   activate: ->
     @editorSubscription = atom.commands.add 'atom-workspace',

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -66,7 +66,7 @@ module.exports =
 
     isGitRepo: ->
       atom.project.repositories.some (item)=>
-        @rootPath.startsWith(item.repo?.workingDirectory) if item
+        @rootPath?.startsWith(item.repo?.workingDirectory) if item
 
     detectColumnFlag: ->
       /(ag|ack)$/.test(@commandString.split(/\s/)[0]) and ~@commandString.indexOf('--column')


### PR DESCRIPTION
I don't expect you to pull this, but perhaps you'd consider a good way to allow optional editor.getSelectedText()

With the code below, I set my @grepCommandFindAndReplace = \, \\, *, \*

This allows me to select C pointers like *UTIMER_CCR in the editor and transforms it to \*UTIMER_CCR as well as escaping any backslashes in a selection.
