### PR TITLE
Escape regex

### DIFF
--- a/lib/atom-fuzzy-grep-view.coffee
+++ b/lib/atom-fuzzy-grep-view.coffee
@@ -3,6 +3,7 @@
 {BufferedProcess, Point} = require 'atom'
 path = require 'path'
 Runner = require './runner'
+escapeStringRegexp = require 'escape-string-regexp'
 
 module.exports =
 class GrepView extends SelectListView
@@ -27,6 +28,8 @@ class GrepView extends SelectListView
       @maxItems = atom.config.get 'atom-fuzzy-grep.maxCandidates'
     atom.config.observe 'atom-fuzzy-grep.preserveLastSearch', =>
       @preserveLastSearch = atom.config.get('atom-fuzzy-grep.preserveLastSearch') is true
+    atom.config.observe 'atom-fuzzy-grep.escapeSelectedText', =>
+      @escapeSelectedText = atom.config.get('atom-fuzzy-grep.escapeSelectedText') is true
 
   getFilterKey: ->
 
@@ -89,7 +92,9 @@ class GrepView extends SelectListView
   setSelection: ->
     editor = atom.workspace.getActiveTextEditor()
     if editor?.getSelectedText()
-      @filterEditorView.setText(editor.getSelectedText())
+      text = editor.getSelectedText()
+      @filterEditorView.setText(
+        if @escapeSelectedText then escapeStringRegexp(text) else text)
 
   destroy: ->
     @detach()

--- a/lib/atom-fuzzy-grep.coffee
+++ b/lib/atom-fuzzy-grep.coffee
@@ -26,6 +26,10 @@ module.exports =
       type: 'boolean'
       default: false
       order: 5
+    escapeSelectedText:
+      type: 'boolean'
+      default: false
+      order: 6
 
   activate: ->
     @editorSubscription = atom.commands.add 'atom-workspace',

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -66,7 +66,7 @@ module.exports =
 
     isGitRepo: ->
       atom.project.repositories.some (item)=>
-        @rootPath.startsWith(item.repo?.workingDirectory) if item
+        @rootPath?.startsWith(item.repo?.workingDirectory) if item
 
     detectColumnFlag: ->
       /(ag|ack)$/.test(@commandString.split(/\s/)[0]) and ~@commandString.indexOf('--column')

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "space-pen": "^5.1.1",
-    "atom-space-pen-views": "^2.0.0"
+    "atom-space-pen-views": "^2.0.0",
+    "escape-string-regexp": "^1.0.3"
   }
 }


### PR DESCRIPTION
Added a single boolean option to 'Escape Selected Text' that uses "escape-string-regexp": "^1.0.3"

Commit 5595f1b also prevents an exception when grepping a file not associated with the active project. Feel free to cherry pick just b31cbfc if you're looking for a better solution to 5595f1b.
