### PR TITLE
atom-fuzzy-grep never finds anything on Windows

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -21,7 +21,7 @@ module.exports =
         @columnArg = false
       [command, args...] = @commandString.split(/\s/)
       args.push @search
-      options = cwd: @rootPath
+      options = cwd: @rootPath, stdio: ['ignore', 'pipe', 'pipe']
 
       stdout = (output)=>
         if listItems.length > atom.config.get('atom-fuzzy-grep.maxCandidates')


### PR DESCRIPTION
Hi geksilla,

There is a port of ag for Windows which can be used with the atom-fuzzy-grep plugin.
(https://github.com/kjk/the_silver_searcher)

But without this fix atom-fuzzy-grep plugin never shows any search results -- just the hourglass icon is displayed infinitely long.
(You might need to disable usage of git-grep in atom-fuzzy-grep's settings to reproduce...)

The reason for this problem is that if ag sees its input stream has been redirected it waits for input from stdin to search in it instead of searching files on disk.
(If you are curious, take a look into ag's "options.c" file the "parse_options" functions, look for "rv = fstat(fileno(stdin), &statbuf);"...
Also, this behavior can be overridden with an undocumented "search-files" command line option)

By default Node's ChildProcess.spawn method "connects" pipes to stdin, stdout, and stderr of the spawned child process.
On Windows the pipe connected to its stdin makes ag think it should search in the input stream instead of files -- to the user it looks like atom-fuzzy-grep is never finding anything or is stuck.

Somehow, on Linux everything works fine without this fix. I did not really have a chance to investigate why. But the changes from this pull-request will not hurt anyway as there is no reason to redirect the child process' stdin because it is not used by atom-fuzzy-grep's code anywhere.
