### PR TITLE
More items fit in search result select list

### DIFF
--- a/lib/atom-fuzzy-grep-view.coffee
+++ b/lib/atom-fuzzy-grep-view.coffee
@@ -6,6 +6,8 @@ Runner = require './runner'
 escapeStringRegexp = require 'escape-string-regexp'
 fuzzyFilter = null
 
+atom.themes.requireStylesheet(require.resolve('../stylesheets/select-list.less'))
+
 module.exports =
 class GrepView extends SelectListView
   preserveLastSearch: false

--- a/stylesheets/select-list.less
+++ b/stylesheets/select-list.less
@@ -1,0 +1,3 @@
+.select-list.atom-fuzzy-grep ol.list-group {
+  max-height: 550px;
+}


### PR DESCRIPTION
Search result overlay was small considering we usually use grep for big projects(too many results).
This scales it up a little bit that can fit 9 items instead of 4 and still doesn't get out of Atom window and doesn't affect similar SelectListViews that other packages use.
