### PR TITLE
Fix git repository detection within a symlink directory

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -68,7 +68,7 @@ module.exports =
 
     isGitRepo: ->
       atom.project.repositories.some (item)=>
-        @rootPath?.startsWith(item.repo?.workingDirectory) if item
+        @rootPath?.startsWith(item.repo?.openedWorkingDirectory) if item
 
     detectColumnFlag: ->
       /(ag|pt|ack)$/.test(@commandString.split(/\s/)[0]) and ~@commandString.indexOf('--column')


### PR DESCRIPTION
When used with project opened by symlink and _'Detect Git Project And Use Git Grep'_ option enabled git repository detection fails since repo's `workingDirectory` contains real path while `rootPath` contains symbolic. Here's a screenshot illustrating issue:

![2016-07-15 17-04-38](https://cloud.githubusercontent.com/assets/64609/16877162/f200f7c6-4ab7-11e6-9567-ba242bc7e0e9.png)
