### PR TITLE
Add support for ripgrep (rg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ If you want to setup another one instead of **ag** here few examples:
 
     grep -r -n --color=never
 
+### [ripgrep](https://github.com/BurntSushi/ripgrep)
+
+    rg --ignore-case --with-filename --no-heading --column
+
 ### git grep
 
     git grep -n -E

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -71,6 +71,6 @@ module.exports =
         @rootPath?.startsWith(item.repo?.openedWorkingDirectory) if item
 
     detectColumnFlag: ->
-      /(ag|pt|ack)$/.test(@commandString.split(/\s/)[0]) and ~@commandString.indexOf('--column')
+      /(ag|pt|ack|rg)$/.test(@commandString.split(/\s/)[0]) and ~@commandString.indexOf('--column')
 
     setEnv: (@env)->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-fuzzy-grep",
   "main": "./lib/atom-fuzzy-grep",
   "version": "0.14.0",
-  "description": "Fuzzy grep project using ag, pt, ack, grep or git-grep",
+  "description": "Fuzzy grep project using ag, pt, ack, grep, ripgrep, or git-grep",
   "keywords": [
     "fuzzy",
     "grep",


### PR DESCRIPTION
Ripgrep is a new grep-like tool written in Rust and has gotten some buzz lately. With the right flags, it produces output that is consumable by fuzzy-grep.

Here, I followed #21 on some small code changes.

When I tried this yesterday, it wasn't working due to an IO issue (burntsushi/ripgrep#35), but I confirmed that the current HEAD works and should work by the next release ~~(0.1.18)~~ (0.2.0).
