### PR TITLE
FEATURE: Allow command line arguments in search

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -21,7 +21,15 @@ module.exports =
         @commandString = atom.config.get 'atom-fuzzy-grep.gitGrepCommandString'
         @columnArg = false
       [command, args...] = @commandString.split(/\s/)
-      args.push @search
+      if @search.indexOf('-') >= 0
+        [argsX, searchX] = @search.split(/--/, 2)
+        argsX = argsX.split(/\s/).map((s)->s.trim()).filter((s)->s.length)
+        args = args.concat(argsX)
+        if typeof(searchX) is 'string'
+          args.push searchX.trim()
+      else
+        args.push @search
+      console.log args
       options = cwd: @rootPath, stdio: ['ignore', 'pipe', 'pipe'], env: @env
 
       stdout = (output)=>


### PR DESCRIPTION
This commit allows extra command line arguments to be entered in the
search dialog. I've found it useful in some cases like the following.

(1) You want to do a case-sensitive search, but keep the insensitive defaults:

    -s COPYRIGHT

(2) You want to limit a search to a specific language:

    -t py -s COPYRIGHT

(3) You want to do multiple searches:

    -s -e Copyright -e COPYRIGHT

Use '--' if you need to do a search expression with spaces with an argument:

    -t py -- AUTHORS OR COPYRIGHTS

I've never used CoffeeScript, so feel free to modify or improve.