### PR TITLE
use coffeescript equality check instead of ===

### DIFF
--- a/lib/atom-fuzzy-grep-view.coffee
+++ b/lib/atom-fuzzy-grep-view.coffee
@@ -138,7 +138,7 @@ class GrepView extends SelectListView
     @toggle()
     editor  = atom.workspace.getActivePaneItem()
     pattern = editor?.getSelectedText()
-    pattern = editor?.getWordUnderCursor() if pattern === ""
+    pattern = editor?.getWordUnderCursor() if pattern is ""
     @filterEditorView.setText(pattern || "")
 
   toggleFileFilter: =>


### PR DESCRIPTION
Thanks for merging #44, I just updated and was getting a coffee script error when trying to invoke! I am not very familiar with coffee script, so I missed that the first time. I think I did my tests with a `==` which works in coffee script, but changed it to `===` out of habit before pushing. 

Sorry for introducing a bug!